### PR TITLE
 mapcontainer can be object too

### DIFF
--- a/src/internal/Manager.js
+++ b/src/internal/Manager.js
@@ -68,7 +68,8 @@ WGL.internal.Manager = function(mapid, mapcontainer) {
 	this.updateMapSize();
 		
 	if (mapcontainer!= null){
-		document.getElementById(mapcontainer).appendChild(this.canvas);
+		 var element = document.getElementById(mapcontainer); // -- SSU enable to append into id or object
+	        (element ? element : mapcontainer).appendChild(this.canvas);
 	} else {
 		mapparentdiv.appendChild(this.canvas);
 	}


### PR DESCRIPTION
extended  mapcontainer - it  can be either id or exsiting DOM object, useful for adding canvas into existing layout of the map.