### PR TITLE
Add popup from internal data, backport popup to example Birmingham

### DIFF
--- a/examples/birmingham/js/init13.js
+++ b/examples/birmingham/js/init13.js
@@ -112,7 +112,7 @@ function visualize(data){
 		charts['speedlimit'] = WGL.createStackBarChart(sl, "ch4", "Speed limit", 'slF');
 
 		//identify
-		var idt = WGL.addIdentifyDimension(data.pts, data.pts_id, 'idt', "data/identify/");
+		var idt = WGL.addIdentifyDimension(data.pts, data.pts_id, 'idt', null, data);
 		idt.onlySelected = false;
 		idt.pointSize = 15;
 		//idt.debug = true;
@@ -140,22 +140,17 @@ function visualize(data){
 		WGL.initFilters();
 		//wgl.render();
 	
-    // point selection
+// point selection
     pw = new WGL.ui.PopupWin("#OpenLayers_Layer_Vector_32_svgRoot", "idt", "Accident Details");
     pw.setProp2html(function (t) {
-      var d =  (new Date(t["timestamp"]*1000));
-      var weekarray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri","Sat"];
-      var wd = weekarray[d.getDate()];
-      var sev = data.sevEnum[t["accident_severity"]-1];
-      var rt = data.rtEnum[t["road_type"]];
-      //speed_limit
+      var d =  (new Date(t.date*1000*60*60));
 
       var s = "<table>";
       s += "<tr><td width='100px'>Date: </td><td>"+d.toDateString()+"</td></tr>";
       s += "<tr><td>Time: </td><td>"+d.toLocaleTimeString()+"</td></tr>";
-      s += "<tr><td>Severity: </td><td>"+sev+"</td></tr>";
-      s += "<tr><td>Road Type: </td><td>"+rt+"</td></tr>";
-      s += "<tr><td>Speed Limit: </td><td>"+t["speed_limit"]+"</td></tr>";
+      s += "<tr><td>Severity: </td><td>"+t.sev+"</td></tr>";
+      s += "<tr><td>Road Type: </td><td>"+t.road_type+"</td></tr>";
+      s += "<tr><td>Speed Limit: </td><td>"+t.speed_limit+"</td></tr>";
       return s;
     });
     pw.setMovemap(function (dx, dy) {
@@ -167,7 +162,11 @@ function visualize(data){
       map.setCenter(ll);
     });
     map.events.register("move",map,function () {
-      pw.zoommove(map.getZoom(), getTopLeftTC());
+	var testElement = document.getElementById('wgl-point-win');
+	if( testElement.classList.contains("wgl-active") ) {
+		pw.zoommove(map.getZoom(), getTopLeftTC());
+        }
+
     });
     // end point selection
 		

--- a/examples/birmingham/js/map.js
+++ b/examples/birmingham/js/map.js
@@ -26,7 +26,10 @@ initMap = function() {
 			  }) ;
 	 
 	  
-	var layer2 = new  OpenLayers.Layer.OSM('osm', 'http://${s}.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png', {});
+	var layer2 = new  OpenLayers.Layer.OSM('osm', ['http://a.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png',
+						       'http://b.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png',
+						       'http://c.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png',
+						       'http://d.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png'], {});
 	       
 	        
     var layer = new OpenLayers.Layer.OSM('', null, {

--- a/src/WGL.js
+++ b/src/WGL.js
@@ -151,16 +151,17 @@ var WGL = (function() {
      * @param {int[]} pts_id array of ID [id1, id2, id3, ...]
      * @param {String} id ID of dimension
      * @param {string} properties_path path to directory with files for identify
+     * @param {string} data array of all pts
      * @returns {WGL.dimension.IdentifyDimension}
      */
-    addIdentifyDimension: function (data, pts_id, id, properties_path) {
+    addIdentifyDimension: function (pts, pts_id, id, properties_path, data) {
       for (var i = 0; i< pts_id.length; i++){
         if (pts_id[i] >= 16777216){
           throw "point ID must be < then 2^24 (3 byte)";
         }
       }
       try { // try create pts buffer
-          manager.addDataBuffer(u.array2TA(data), 2, 'wPoint');
+          manager.addDataBuffer(u.array2TA(pts), 2, 'wPoint');
       } catch (err) {
           console.warn(err);
       }
@@ -170,7 +171,7 @@ var WGL = (function() {
       } catch (err) {
           console.warn(err);
       }
-      var dim = new WGL.dimension.IdentifyDimension(id, properties_path);
+      var dim = new WGL.dimension.IdentifyDimension(id, properties_path, data);
       this._dimensions[id] = dim;
       return dim;
     },

--- a/src/WGL.js
+++ b/src/WGL.js
@@ -151,7 +151,7 @@ var WGL = (function() {
      * @param {int[]} pts_id array of ID [id1, id2, id3, ...]
      * @param {String} id ID of dimension
      * @param {string} properties_path path to directory with files for identify
-     * @param {string} data array of all pts
+     * @param {Object} data array of all pts
      * @returns {WGL.dimension.IdentifyDimension}
      */
     addIdentifyDimension: function (pts, pts_id, id, properties_path, data) {

--- a/src/dimension/IdentifyDimension.js
+++ b/src/dimension/IdentifyDimension.js
@@ -2,6 +2,7 @@
  * Class identify objects in the map
  * @param id {String} ID of the dimension
  * @param properties_path {String} path to folder with files for identify
+ * @param {Object} data array of all pts
  * @constructor
  */
 WGL.dimension.IdentifyDimension = function (id, properties_path) {

--- a/src/dimension/IdentifyDimension.js
+++ b/src/dimension/IdentifyDimension.js
@@ -5,7 +5,7 @@
  * @param {Object} data array of all pts
  * @constructor
  */
-WGL.dimension.IdentifyDimension = function (id, properties_path) {
+WGL.dimension.IdentifyDimension = function (id, properties_path, data) {
   // ID of dim
   this.id = id;
   this.isSpatial = true;
@@ -195,38 +195,23 @@ WGL.dimension.IdentifyDimension = function (id, properties_path) {
     var idt = this.identify(x, y);
     var id = idt[0];
     var num =idt[1];
-    if (num != 0){
-        var file = Math.floor(id/10) + '.txt';
-        var url = this.dataPath + file
-        if (this.dataPath == null) { // internal data popup only
-            var t = [];
-            Object.keys(data).forEach(function(key,index) {
-                t[key] = data[key][id];
-            });
-            callback(t);
-        }
-        else { // additional external data download
-	        $.get(url, function (data) {
-    	        var dataArray = $.csv.toObjects(data,{
-    	            delimiter:"'",
-    	            separator:','
-    	        });
-    	        dataArray.forEach(function (t) {
-    	            if (t['ID'] == id){
-    	                t['webgl_num_pts'] = num;
-	                    callback(t)
-    	            } 
-    	        })
-	      })
-	      .fail(function() { // error log for HTTP 404
-		      console.log( "!Data file download failed: " + url + ".");
-	      })
-      }
+    this.getPropertiesById (id, num, callback)
     }
   };
 
   this.getPropertiesById = function (id, num, callback) {
       if (num != 0){
+      	if (this.dataPath == null) {
+            var t = [];
+            Object.keys(data).forEach(function(key,index) {
+                t[key] = data[key][id];
+            });
+            t["ID"]=id;
+	    t['webgl_num_pts'] = num;
+            callback(t);
+        }
+        else {
+
           var file = Math.floor(id/10) + '.txt';
           $.get(this.dataPath + file, function (data) {
               var dataArray = $.csv.toObjects(data,{
@@ -239,7 +224,12 @@ WGL.dimension.IdentifyDimension = function (id, properties_path) {
                       callback(t)
                   }
               })
-          });
+	      .fail(function() {
+		      console.log( "!Data file download failed: " + url + ".");
+
+              });
+	  })
+	}
       }
   };
 };

--- a/src/dimension/IdentifyDimension.js
+++ b/src/dimension/IdentifyDimension.js
@@ -195,19 +195,32 @@ WGL.dimension.IdentifyDimension = function (id, properties_path) {
     var id = idt[0];
     var num =idt[1];
     if (num != 0){
-      var file = Math.floor(id/10) + '.txt';
-      $.get(this.dataPath + file, function (data) {
-        var dataArray = $.csv.toObjects(data,{
-          delimiter:"'",
-          separator:','
-        });
-        dataArray.forEach(function (t) {
-          if (t['ID'] == id){
-            t['webgl_num_pts'] = num;
-            callback(t)
-          }
-        })
-      });
+        var file = Math.floor(id/10) + '.txt';
+        var url = this.dataPath + file
+        if (this.dataPath == null) { // internal data popup only
+            var t = [];
+            Object.keys(data).forEach(function(key,index) {
+                t[key] = data[key][id];
+            });
+            callback(t);
+        }
+        else { // additional external data download
+	        $.get(url, function (data) {
+    	        var dataArray = $.csv.toObjects(data,{
+    	            delimiter:"'",
+    	            separator:','
+    	        });
+    	        dataArray.forEach(function (t) {
+    	            if (t['ID'] == id){
+    	                t['webgl_num_pts'] = num;
+	                    callback(t)
+    	            } 
+    	        })
+	      })
+	      .fail(function() { // error log for HTTP 404
+		      console.log( "!Data file download failed: " + url + ".");
+	      })
+      }
     }
   };
 

--- a/src/dimension/IdentifyDimension.js
+++ b/src/dimension/IdentifyDimension.js
@@ -196,7 +196,6 @@ WGL.dimension.IdentifyDimension = function (id, properties_path, data) {
     var id = idt[0];
     var num =idt[1];
     this.getPropertiesById (id, num, callback)
-    }
   };
 
   this.getPropertiesById = function (id, num, callback) {
@@ -228,7 +227,7 @@ WGL.dimension.IdentifyDimension = function (id, properties_path, data) {
 		      console.log( "!Data file download failed: " + url + ".");
 
               });
-	  })
+	})
 	}
       }
   };

--- a/src/ui/PopupWin.js
+++ b/src/ui/PopupWin.js
@@ -188,7 +188,15 @@ WGL.ui.PopupWin = function (map_win_id, idt_dim, title) {
 
                     setVisibility(false);
 
-                    lngLat = map.unproject([e.offsetX, e.offsetY]);
+                    if (typeof map.unproject === "function") { //mapbox lib
+                       lngLat = map.unproject([e.offsetX, e.offsetY]); 
+                    }
+                    else { //openlayers native
+                       var px = new OpenLayers.Pixel(e.offsetX, e.offsetY);
+                       np = map.getLonLatFromPixel(px);
+                       lngLat = np.transform(merc, wgs); 
+                    }
+
 
                     last_position = [t['ID'], t['webgl_num_pts'], lngLat.lng, lngLat.lat];
 
@@ -264,7 +272,14 @@ WGL.ui.PopupWin = function (map_win_id, idt_dim, title) {
      */
     this.zoommove = function () {
         if(lngLat != null) {
-            let point = map.project(lngLat);
+            if (typeof map.project === "function") { //mapbox lib
+                point = map.project(lngLat);
+	        } else { // openlayers native
+                var ll = new OpenLayers.LonLat(lngLat.lon, lngLat.lat);
+                np = ll.transform(wgs, merc);
+                point =  map.getPixelFromLonLat(np);
+            }
+
             setPosition(point.x, point.y);
         }
     };
@@ -276,7 +291,14 @@ WGL.ui.PopupWin = function (map_win_id, idt_dim, title) {
 
             lngLat = [position[2], position[3]];
 
-            let point = map.project(lngLat);
+            if (typeof map.project === "function") { //mapbox lib
+                point = map.project(lngLat);
+            } else { //openlayers native
+                var ll = new OpenLayers.LonLat(lngLat.lon, lngLat.lat);
+                np = ll.transform(wgs, merc);
+                point =  map.getPixelFromLonLat(np);
+            }
+
 
             WGL.getDimension(idt_dim).getPropertiesById(position[0], position[1], function (t) {
 


### PR DESCRIPTION
WGL core:
I added second datasource of popup - from internal loaded data instead from only external download file. I added console.log for HTTP 404 and I added test on unregistred MapBox function (typeof map.project === "function") with workaround by OpenLayers.

Example Birmingham:
I fixed broken popup, I added internal data popup. I fixed problem with close of popup (Closed popup is reopen by user move of map canvas).